### PR TITLE
Fix some bugs

### DIFF
--- a/UmlYangTools/xmi2yang/generator/yangprocessors.js
+++ b/UmlYangTools/xmi2yang/generator/yangprocessors.js
@@ -421,6 +421,7 @@ module.exports = {
                                         if(kpath == ""){
                                             kpath = "path '" + "/" + Util.yangifyName(ele[i].instancePath);
                                         }
+                                        kpath += "'";
                                         var newType = new yangModels.Type("leafref", '', kpath, "", "", "", ele[i].fileName);
                                         var newAtt = new yangModels.Leaf(ele[i].name + "-" + ele[i].key[kk], '', undefined, undefined, undefined, newType, undefined, undefined, ele[i].fileName);
                                         newObj.children.push(newAtt);
@@ -449,6 +450,7 @@ module.exports = {
                                         if(kpath == ""){
                                             kpath = "path '" + "/" + Util.yangifyName(ele[i].instancePath);
                                         }
+                                        kpath += "'";
                                         var newType = new yangModels.Type("leafref", '', kpath, "", "", "", ele[i].fileName);
                                         var newAtt = new yangModels.Leaf(ele[i].name + "-" + ele[i].key[kk], '', undefined, undefined, undefined, newType, undefined, undefined, ele[i].fileName);
                                         newObj.children.push(newAtt);
@@ -474,6 +476,7 @@ module.exports = {
                                             if(kpath == ""){
                                                 kpath = "path '" + "/" + Util.yangifyName(ele[i].instancePath);
                                             }
+                                            kpath += "'";
                                             var newType = new yangModels.Type("leafref", '', kpath, "", "", "", ele[i].fileName);
                                             var newAtt = new yangModels.Leaf(ele[i].name + "-" + ele[i].key[kk], '', undefined, undefined, undefined, newType, undefined, undefined, ele[i].fileName);
                                             newObj.children.push(newAtt);
@@ -510,7 +513,31 @@ module.exports = {
             }
             //create "rpc"
             if(ele[i].nodeType === "rpc"){
+
                 for (var j = 0; j < ele[i].attribute.length; j++) {
+
+                    if(ele[i].attribute[j].nodeType == "list" || ele[i].attribute[j].nodeType == "container"){
+                        for (var k = 0; k < store.Class.length; k++) {
+                            var rpcclazz = store.Class[k];
+
+                            if (rpcclazz.id == ele[i].attribute[j].type) {
+                                ele[i].attribute[j].isAbstract = rpcclazz.isAbstract;
+
+                                if (rpcclazz.type !== "Class") {
+                                    ele[i].attribute[j].isleafRef = false;
+                                    ele[i].attribute[j].isGrouping = true;
+                                }
+
+                                ele[i].attribute[j].isUsesNo = k;
+                                ele[i].attribute[j].key = rpcclazz.key;
+                                ele[i].attribute[j].keyid = rpcclazz.keyid;
+                                ele[i].attribute[j].keyvalue = rpcclazz.keyvalue;
+
+                            }
+                        }
+
+                    }
+
                     var pValue = ele[i].attribute[j];
                     for(var k = 0; k < store.Typedef.length; k++){
                         var typeDef = store.Typedef[k];
@@ -720,12 +747,15 @@ module.exports = {
 
             var tempPath;
             for(var t = 0; t < store.packages.length; t++) {
+
                 var package = store.packages[t];
+
                 if (package.path === "") {
                     tempPath = package.name;
                 } else {
                     tempPath = package.path + "-" + package.name
                 }
+
                 if (tempPath === ele[i].path && package.fileName === ele[i].fileName) {
                     //create a new node if "ele" needs to be instantiate
                     if (ele[i].nodeType === "notification" ||rootFlag==1) {

--- a/UmlYangTools/xmi2yang/model/yang/package.js
+++ b/UmlYangTools/xmi2yang/model/yang/package.js
@@ -34,12 +34,49 @@ Package.prototype.writeNode = function (layer) {
         PRE += '\t';
     }
 
+    if(this.name.toLowerCase() === "typedefinitions"){
+        var name1 = "/****************************************\r\n* typedef statements\r\n**************************************/";
+        var name2 = "/*********************************************\r\n* grouping statements for complex data types\r\n*******************************************/";
+
+        var mychildren1 = new Array();
+        var mychildren2 = new Array();
+        var children1 = "";
+        var children2 = "";
+
+        for (var i = 0; i < this.children.length; i++) {
+            if(this.children[i].nodeType == "typedef"){
+                mychildren1.push(this.children[i]);
+            }else{
+                mychildren2.push(this.children[i]);
+            }
+        }
+
+        if (mychildren1) {
+            mychildren1.map(function(child) {
+                children1 += child.writeNode(layer + 1);
+            });
+        }
+        if (mychildren2) {
+            mychildren2.map(function(child) {
+                children2 += child.writeNode(layer + 1);
+            });
+        }
+
+        var s = Util.yangifyName(name1) + " \r\n" +
+            children1 +
+            "\r\n" +
+            Util.yangifyName(name2) + " \r\n" +
+            children2 +
+            "\r\n";
+        return s;
+    }
+
     if(this.name.toLowerCase() === "definitionsofreferences") {
-        var name = "/*************************\r\n* definitions of references\r\n*************************/";//changed
+        var name = "/********************************************\r\n* grouping statements for object references\r\n********************************************/";//changed
     }else if(this.name.toLowerCase() === "objectclasses"){
-        var name = "/***********************\r\n* package object-classes\r\n**********************/";//changed
+        var name = "/****************************************\r\n* grouping statements for object classes\r\n**************************************/";//changed
     }else{
-        var name = "/***********************\r\n* package " + this.name + "\r\n**********************/";
+        var name = "/****************************************\r\n* package " + this.name + "\r\n**************************************/";
     }
     name = name.replace(/\r\n/g, '\r\n' + PRE);
     var descript;

--- a/UmlYangTools/xmi2yang/model/yang/rpc.js
+++ b/UmlYangTools/xmi2yang/model/yang/rpc.js
@@ -25,6 +25,7 @@ function rpc(name, descrip, feature, status, fileName) {
     this.input = [];
 }
 rpc.prototype.buildChild = function (att, type, rpcType) {
+
     if(type == "leaf" || type == "leaf-list"){
         //translate the "integer" to "uint32"
         switch(att.type){
@@ -53,15 +54,10 @@ rpc.prototype.buildChild = function (att, type, rpcType) {
         case "list":
             obj = new Node(att.name, att.description, att.nodeType, att['max-elements'], att['min-elements'], att.id, att.config, att.isOrdered, att.support, att.status, att.fileName);
             if (att.isUses) {
-                //if (att.config) {
-                    if (att.key) {
-                        /*if(obj.key.length != 0){
-                            console.log("!");
-                        }*/
-                        obj.key = att.key;
-                        obj.keyid = att.keyid;
-                    }
-                //}
+                if (att.key) {
+                    obj.key = att.key;
+                    obj.keyid = att.keyid;
+                }
                 obj.isGrouping = att.isGrouping;
                 obj.buildUses(att);
             }


### PR DESCRIPTION
Fix the following bugs:
1. The YANG heading "definitions of references" should be replaced by "grouping statements for object references"
2. The YANG heading "package object-classes" should be replaced by"grouping statements for object classes"
3. Complex data types (mapped to groupings) and simple data types (mapped to typedefs) are under the same YANG heading "package type-definitions"
4. Complex data types (mapped to groupings) should be under the YANG heading "grouping statements for complex data types"
5. The path expressions don't have a closing apostrophe (')
Please help do the review. @karthik-sethuraman 